### PR TITLE
Issue #3: Refinements

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -56,12 +56,12 @@ pollControllers()
 
 Profile is selected by matching the frontmost app's bundle ID against `profile.apps[]`, falling back to the `"default"` profile. Within a profile, bindings resolve in this priority order (highest wins):
 
-1. Combo key (`modifier+button`) in top-level `config.global`
+1. Combo key (`modifier+button`) in active mode bindings
 2. Combo key in `profile.global`
-3. Combo key in active mode bindings
-4. Plain key in top-level `config.global`
+3. Combo key in top-level `config.global`
+4. Plain key in active mode bindings (`profile.modes[activeModeString]`)
 5. Plain key in `profile.global`
-6. Plain key in active mode bindings (`profile.modes[activeModeString]`)
+6. Plain key in top-level `config.global` (cross-profile defaults)
 
 Combo keys use the syntax `"<modifier>+<button>"` (e.g., `"X+dpad_up"`) in any bindings dictionary. When multiple buttons are held, `ButtonID.allCases` order determines which modifier is tried first.
 

--- a/PadIO/ControllerManager.swift
+++ b/PadIO/ControllerManager.swift
@@ -512,34 +512,42 @@ final class ControllerManager: ObservableObject {
 
     // MARK: - Hold helpers
 
-    /// Checks if the binding for a button has a `hold` field. If so, builds both
-    /// the press and hold actions and returns them as a HoldContext.
+    /// Checks if any config in the cascade for this button has a `hold` field.
+    /// If so, builds both the press and hold actions (merging from different cascade levels)
+    /// and returns them as a HoldContext.
     private func resolveHoldConfig(buttonID: ButtonID, heldButtons: [ButtonID: Bool]) -> HoldContext? {
         let config = configLoader.config
         let bundleID = appObserver.frontmostBundleID
         guard let (profileName, profile) = mappingResolver.resolveProfile(bundleID: bundleID, config: config) else { return nil }
         let modeName = profileModes[profileName] ?? profile.defaultMode
 
-        guard let actionConfig = mappingResolver.resolveActionConfig(
+        // Collect all matching configs across the cascade
+        let allConfigs = mappingResolver.resolveAllConfigs(
             button: buttonID,
             heldButtons: heldButtons,
             profile: profile,
             activeMode: modeName,
             config: config
-        ) else { return nil }
+        )
+        guard !allConfigs.isEmpty else { return nil }
 
-        // Only enter hold mode if the config has a hold field
-        guard let holdActionConfig = actionConfig.hold else { return nil }
+        // Find the effective hold: first config in cascade with a hold field
+        guard let holdSource = allConfigs.first(where: { $0.hold != nil }),
+              let holdActionConfig = holdSource.hold,
+              holdActionConfig.type != "none" else {
+            return nil
+        }
 
-        guard let pressAction = mappingResolver.resolve(
-            button: buttonID,
-            heldButtons: heldButtons,
-            profile: profile,
-            activeMode: modeName,
-            config: config
-        ) else { return nil }
+        // Find the effective press: winning config, but if "none", inherit from lower levels
+        let pressActionConfig: ActionConfig
+        if allConfigs[0].type == "none" {
+            pressActionConfig = allConfigs.dropFirst().first(where: { $0.type != "none" }) ?? allConfigs[0]
+        } else {
+            pressActionConfig = allConfigs[0]
+        }
 
-        guard let holdAction = MappingResolver().buildActionPublic(from: holdActionConfig, mappingConfig: config) else { return nil }
+        guard let pressAction = mappingResolver.buildActionPublic(from: pressActionConfig, mappingConfig: config) else { return nil }
+        guard let holdAction = mappingResolver.buildActionPublic(from: holdActionConfig, mappingConfig: config) else { return nil }
 
         return HoldContext(
             pressAction: pressAction,

--- a/PadIO/ControllerManager.swift
+++ b/PadIO/ControllerManager.swift
@@ -392,14 +392,19 @@ final class ControllerManager: ObservableObject {
     ) {
         switch action {
         case .keystroke(let keyCode, let flags):
-            inputHandler.emitKeystroke(keyCode: keyCode, flags: flags)
+            // Merge any active modifier holds so held modifiers aren't dropped
+            let mergedFlags = flags.union(heldModifierFlags())
+            inputHandler.emitKeystroke(keyCode: keyCode, flags: mergedFlags)
 
         case .sequence(let steps, let delay):
+            // Merge any active modifier holds into each step
+            let modFlags = heldModifierFlags()
+            let mergedSteps = steps.map { (keyCode: $0.keyCode, flags: $0.flags.union(modFlags)) }
             // Dispatch off main thread — usleep in emitSequence blocks the calling thread,
             // which prevents CGEvents from being delivered when triggered from menu callbacks.
             let handler = inputHandler
             DispatchQueue.global(qos: .userInteractive).async {
-                handler.emitSequence(steps: steps, delay: delay)
+                handler.emitSequence(steps: mergedSteps, delay: delay)
             }
 
         case .textInput(let text):
@@ -489,10 +494,10 @@ final class ControllerManager: ObservableObject {
             inputHandler.emitMouseUp(button: .right)
 
         case .keyDown(let keyCode, let flags):
-            inputHandler.emitKeyDown(keyCode: keyCode, flags: flags)
+            inputHandler.emitKeyDown(keyCode: keyCode, flags: flags.union(heldModifierFlags()))
 
         case .keyUp(let keyCode, let flags):
-            inputHandler.emitKeyUp(keyCode: keyCode, flags: flags)
+            inputHandler.emitKeyUp(keyCode: keyCode, flags: flags.union(heldModifierFlags()))
 
         case .modifierHold(let flags):
             inputHandler.emitModifierDown(flags: flags)
@@ -568,6 +573,20 @@ final class ControllerManager: ObservableObject {
             // (executeAction will just fire the action again, which is fine for one-shots)
             return .keyUp(keyCode: 0, flags: [])
         }
+    }
+
+    /// Returns the union of all modifier flags currently held via modifierHold actions.
+    private func heldModifierFlags() -> CGEventFlags {
+        var flags: CGEventFlags = []
+        for (_, buttons) in holdStates {
+            for (_, state) in buttons {
+                if case .held(let context) = state,
+                   case .modifierHold(let heldFlags) = context.holdAction {
+                    flags.insert(heldFlags)
+                }
+            }
+        }
+        return flags
     }
 
     /// Returns true if any button on any controller has an active mouse hold.

--- a/PadIO/ControllerManager.swift
+++ b/PadIO/ControllerManager.swift
@@ -493,6 +493,12 @@ final class ControllerManager: ObservableObject {
 
         case .keyUp(let keyCode, let flags):
             inputHandler.emitKeyUp(keyCode: keyCode, flags: flags)
+
+        case .modifierHold(let flags):
+            inputHandler.emitModifierDown(flags: flags)
+
+        case .modifierRelease(let flags):
+            inputHandler.emitModifierUp(flags: flags)
         }
     }
 
@@ -555,6 +561,8 @@ final class ControllerManager: ObservableObject {
             return .rightClickRelease
         case .keystroke(let keyCode, let flags):
             return .keyUp(keyCode: keyCode, flags: flags)
+        case .modifierHold(let flags):
+            return .modifierRelease(flags: flags)
         default:
             // For actions without an explicit release, use a no-op by returning the same
             // (executeAction will just fire the action again, which is fine for one-shots)

--- a/PadIO/ControllerManager.swift
+++ b/PadIO/ControllerManager.swift
@@ -499,6 +499,9 @@ final class ControllerManager: ObservableObject {
         case .keyUp(let keyCode, let flags):
             inputHandler.emitKeyUp(keyCode: keyCode, flags: flags.union(heldModifierFlags()))
 
+        case .noop:
+            break
+
         case .modifierHold(let flags):
             inputHandler.emitModifierDown(flags: flags)
 

--- a/PadIO/ControllerManager.swift
+++ b/PadIO/ControllerManager.swift
@@ -8,6 +8,7 @@ import Foundation
 import Combine
 import GameController
 import CoreGraphics
+import QuartzCore
 
 @MainActor
 final class ControllerManager: ObservableObject {
@@ -108,8 +109,10 @@ final class ControllerManager: ObservableObject {
     }
 
     private func disconnectController(_ controller: GCController) {
+        let id = ObjectIdentifier(controller)
         connectedControllers.removeAll { $0 == controller }
-        previousButtonStates.removeValue(forKey: ObjectIdentifier(controller))
+        previousButtonStates.removeValue(forKey: id)
+        holdStates.removeValue(forKey: id)
         hapticController.controllerDisconnected(controller)
         print("[PadIO] Controller disconnected: \(controller.vendorName ?? "Unknown")")
     }
@@ -122,6 +125,29 @@ final class ControllerManager: ObservableObject {
     /// Minimum axis deflection required to produce mouse/scroll events (eliminates stick drift).
     private static let axisDeadzone: Float = 0.1
 
+    // MARK: - Hold state machine
+
+    /// Duration in seconds a button must be held before the hold action fires.
+    private static let holdThreshold: CFTimeInterval = 0.3
+
+    /// Context captured at the moment a hold-capable button is first pressed.
+    private struct HoldContext {
+        let pressAction: Action
+        let holdAction: Action
+        let profile: ProfileConfig
+        let profileName: String
+        let currentMode: String
+    }
+
+    /// Per-button hold tracking state.
+    private enum HoldState {
+        case pending(pressTime: CFTimeInterval, context: HoldContext)
+        case held(context: HoldContext)
+    }
+
+    /// Active hold states per controller and button.
+    private var holdStates: [ObjectIdentifier: [ButtonID: HoldState]] = [:]
+
     private func startPollingTimer() {
         // Poll at ~60Hz — fast enough to catch quick taps
         Timer.scheduledTimer(withTimeInterval: 1.0 / 60.0, repeats: true) { [weak self] _ in
@@ -131,21 +157,52 @@ final class ControllerManager: ObservableObject {
 
     private func pollControllers() {
         let threshold = Float(configLoader.config.triggerThreshold ?? 0.5)
+        let now = CACurrentMediaTime()
         for controller in GCController.controllers() {
             guard let gamepad = controller.extendedGamepad else { continue }
             let id = ObjectIdentifier(controller)
             var prev = previousButtonStates[id] ?? [:]
+            var holds = holdStates[id] ?? [:]
 
-            // Edge-triggered button dispatch
             for buttonID in ButtonID.allCases {
                 let pressed = isPressed(buttonID: buttonID, gamepad: gamepad, threshold: threshold)
                 let wasPressed = prev[buttonID] ?? false
+
                 if pressed && !wasPressed {
-                    handleMappedButton(buttonID, heldButtons: prev)
+                    // Press edge — check if this binding has a hold action
+                    if let holdConfig = resolveHoldConfig(buttonID: buttonID, heldButtons: prev) {
+                        holds[buttonID] = .pending(pressTime: now, context: holdConfig)
+                    } else {
+                        handleMappedButton(buttonID, heldButtons: prev)
+                    }
+                } else if pressed && wasPressed {
+                    // Still held — check for threshold crossing
+                    if case .pending(let pressTime, let context) = holds[buttonID],
+                       now - pressTime >= Self.holdThreshold {
+                        // Threshold exceeded — fire hold action
+                        let holdAction = convertToHoldAction(context.holdAction)
+                        executeAction(holdAction, profile: context.profile, profileName: context.profileName, currentMode: context.currentMode)
+                        holds[buttonID] = .held(context: context)
+                    }
+                } else if !pressed && wasPressed {
+                    // Release edge — handle hold state
+                    if let holdState = holds[buttonID] {
+                        switch holdState {
+                        case .pending(_, let context):
+                            // Released before threshold — fire the tap (press) action
+                            executeAction(context.pressAction, profile: context.profile, profileName: context.profileName, currentMode: context.currentMode)
+                        case .held(let context):
+                            // Released after hold — fire the release counterpart
+                            let releaseAction = releaseAction(for: context.holdAction)
+                            executeAction(releaseAction, profile: context.profile, profileName: context.profileName, currentMode: context.currentMode)
+                        }
+                        holds.removeValue(forKey: buttonID)
+                    }
                 }
                 prev[buttonID] = pressed
             }
             previousButtonStates[id] = prev
+            holdStates[id] = holds
 
             // Continuous axis dispatch (mouse move / scroll) — only when no overlay is visible
             guard !helpOverlay.isVisible && !modePicker.isVisible && !customMenu.isVisible else { continue }
@@ -171,9 +228,14 @@ final class ControllerManager: ObservableObject {
             let (rawX, rawY) = readAxisValues(axisID: axisID, gamepad: gamepad)
 
             // Apply deadzone — treat small deflections as zero to suppress stick drift
-            let x = abs(rawX) > Self.axisDeadzone ? rawX : 0
-            let y = abs(rawY) > Self.axisDeadzone ? rawY : 0
-            guard x != 0 || y != 0 else { continue }
+            let deadX = abs(rawX) > Self.axisDeadzone ? rawX : Float(0)
+            let deadY = abs(rawY) > Self.axisDeadzone ? rawY : Float(0)
+            guard deadX != 0 || deadY != 0 else { continue }
+
+            // Apply quadratic response curve: preserves sign, amplifies large inputs,
+            // gives fine control near center while keeping full-deflection speed.
+            let x = deadX * abs(deadX)
+            let y = deadY * abs(deadY)
 
             // Apply modifier multiplier when the modifier button is held
             let modMult: CGFloat
@@ -192,7 +254,11 @@ final class ControllerManager: ObservableObject {
             switch mapping.kind {
             case .mouseMove:
                 // Screen Y axis is flipped: positive stick-Y = up = negative screen-Y
-                inputHandler.emitMouseMove(dx: dx, dy: -dy)
+                if let btn = heldMouseButton() {
+                    inputHandler.emitMouseDrag(dx: dx, dy: -dy, button: btn)
+                } else {
+                    inputHandler.emitMouseMove(dx: dx, dy: -dy)
+                }
                 print("[PadIO] \(axisID.rawValue) | mouse_move dx=\(String(format: "%.1f", dx)) dy=\(String(format: "%.1f", -dy))")
             case .scroll:
                 inputHandler.emitScroll(dx: dx, dy: dy)
@@ -329,7 +395,12 @@ final class ControllerManager: ObservableObject {
             inputHandler.emitKeystroke(keyCode: keyCode, flags: flags)
 
         case .sequence(let steps, let delay):
-            inputHandler.emitSequence(steps: steps, delay: delay)
+            // Dispatch off main thread — usleep in emitSequence blocks the calling thread,
+            // which prevents CGEvents from being delivered when triggered from menu callbacks.
+            let handler = inputHandler
+            DispatchQueue.global(qos: .userInteractive).async {
+                handler.emitSequence(steps: steps, delay: delay)
+            }
 
         case .textInput(let text):
             inputHandler.emitText(text)
@@ -338,7 +409,8 @@ final class ControllerManager: ObservableObject {
             inputHandler.emitMediaKey(keyType: keyType)
 
         case .modeSelect:
-            let modes = Array(profile.modes.keys.sorted())
+            let config = configLoader.config
+            let modes = allModeNames(profile: profile, config: config)
             guard !modes.isEmpty else { return }
             modePicker.show(modes: modes, currentMode: currentMode) { [weak self] selectedMode in
                 guard let self else { return }
@@ -348,21 +420,22 @@ final class ControllerManager: ObservableObject {
             }
 
         case .prevMode:
-            let modes = profile.modes.keys.sorted()
+            let modes = allModeNames(profile: profile, config: configLoader.config)
             guard !modes.isEmpty else { return }
             let idx = modes.firstIndex(of: currentMode) ?? 0
             let newMode = modes[(idx - 1 + modes.count) % modes.count]
             switchMode(newMode, profileName: profileName)
 
         case .nextMode:
-            let modes = profile.modes.keys.sorted()
+            let modes = allModeNames(profile: profile, config: configLoader.config)
             guard !modes.isEmpty else { return }
             let idx = modes.firstIndex(of: currentMode) ?? 0
             let newMode = modes[(idx + 1) % modes.count]
             switchMode(newMode, profileName: profileName)
 
         case .setMode(let name):
-            guard profile.modes[name] != nil else {
+            let config = configLoader.config
+            guard profile.modes[name] != nil || config.sharedModes?[name] != nil else {
                 print("[PadIO] setMode: unknown mode '\(name)' in profile '\(profileName)'")
                 return
             }
@@ -379,7 +452,7 @@ final class ControllerManager: ObservableObject {
                 guard let self else { return }
                 guard menuConfig.items.indices.contains(index) else { return }
                 let itemAction = menuConfig.items[index].action
-                guard let action = MappingResolver().buildActionPublic(from: itemAction) else { return }
+                guard let action = MappingResolver().buildActionPublic(from: itemAction, mappingConfig: self.configLoader.config) else { return }
                 self.executeAction(action, profile: profile, profileName: profileName, currentMode: currentMode)
             }
 
@@ -402,7 +475,134 @@ final class ControllerManager: ObservableObject {
                 duration: duration
             )
             hapticController.rumbleAll(params: params)
+
+        case .leftClickHold:
+            inputHandler.emitMouseDown(button: .left)
+
+        case .leftClickRelease:
+            inputHandler.emitMouseUp(button: .left)
+
+        case .rightClickHold:
+            inputHandler.emitMouseDown(button: .right)
+
+        case .rightClickRelease:
+            inputHandler.emitMouseUp(button: .right)
+
+        case .keyDown(let keyCode, let flags):
+            inputHandler.emitKeyDown(keyCode: keyCode, flags: flags)
+
+        case .keyUp(let keyCode, let flags):
+            inputHandler.emitKeyUp(keyCode: keyCode, flags: flags)
         }
+    }
+
+    // MARK: - Hold helpers
+
+    /// Checks if the binding for a button has a `hold` field. If so, builds both
+    /// the press and hold actions and returns them as a HoldContext.
+    private func resolveHoldConfig(buttonID: ButtonID, heldButtons: [ButtonID: Bool]) -> HoldContext? {
+        let config = configLoader.config
+        let bundleID = appObserver.frontmostBundleID
+        guard let (profileName, profile) = mappingResolver.resolveProfile(bundleID: bundleID, config: config) else { return nil }
+        let modeName = profileModes[profileName] ?? profile.defaultMode
+
+        guard let actionConfig = mappingResolver.resolveActionConfig(
+            button: buttonID,
+            heldButtons: heldButtons,
+            profile: profile,
+            activeMode: modeName,
+            config: config
+        ) else { return nil }
+
+        // Only enter hold mode if the config has a hold field
+        guard let holdActionConfig = actionConfig.hold else { return nil }
+
+        guard let pressAction = mappingResolver.resolve(
+            button: buttonID,
+            heldButtons: heldButtons,
+            profile: profile,
+            activeMode: modeName,
+            config: config
+        ) else { return nil }
+
+        guard let holdAction = MappingResolver().buildActionPublic(from: holdActionConfig, mappingConfig: config) else { return nil }
+
+        return HoldContext(
+            pressAction: pressAction,
+            holdAction: holdAction,
+            profile: profile,
+            profileName: profileName,
+            currentMode: modeName
+        )
+    }
+
+    /// Converts a hold action to its "activated" form. Keystrokes become key-down only.
+    private func convertToHoldAction(_ action: Action) -> Action {
+        switch action {
+        case .keystroke(let keyCode, let flags):
+            return .keyDown(keyCode: keyCode, flags: flags)
+        default:
+            return action
+        }
+    }
+
+    /// Returns the release counterpart for a hold action.
+    private func releaseAction(for holdAction: Action) -> Action {
+        switch holdAction {
+        case .leftClickHold:
+            return .leftClickRelease
+        case .rightClickHold:
+            return .rightClickRelease
+        case .keystroke(let keyCode, let flags):
+            return .keyUp(keyCode: keyCode, flags: flags)
+        default:
+            // For actions without an explicit release, use a no-op by returning the same
+            // (executeAction will just fire the action again, which is fine for one-shots)
+            return .keyUp(keyCode: 0, flags: [])
+        }
+    }
+
+    /// Returns true if any button on any controller has an active mouse hold.
+    private func isMouseHeld() -> Bool {
+        for (_, buttons) in holdStates {
+            for (_, state) in buttons {
+                if case .held(let context) = state {
+                    switch context.holdAction {
+                    case .leftClickHold, .rightClickHold:
+                        return true
+                    default:
+                        continue
+                    }
+                }
+            }
+        }
+        return false
+    }
+
+    /// Returns the mouse button being held, if any.
+    private func heldMouseButton() -> CGMouseButton? {
+        for (_, buttons) in holdStates {
+            for (_, state) in buttons {
+                if case .held(let context) = state {
+                    switch context.holdAction {
+                    case .leftClickHold:
+                        return .left
+                    case .rightClickHold:
+                        return .right
+                    default:
+                        continue
+                    }
+                }
+            }
+        }
+        return nil
+    }
+
+    /// Returns the sorted union of profile mode names and shared mode names.
+    private func allModeNames(profile: ProfileConfig, config: MappingConfig) -> [String] {
+        var names = Set(profile.modes.keys)
+        if let shared = config.sharedModes { names.formUnion(shared.keys) }
+        return names.sorted()
     }
 
     private func switchMode(_ modeName: String, profileName: String) {

--- a/PadIO/InputHandler.swift
+++ b/PadIO/InputHandler.swift
@@ -215,6 +215,67 @@ struct InputHandler {
         event.post(tap: .cgSessionEventTap)
     }
 
+    // MARK: - Individual key down / key up
+
+    /// Emit only a key-down event (no matching key-up). Used for hold actions.
+    func emitKeyDown(keyCode: CGKeyCode, flags: CGEventFlags = []) {
+        let source = CGEventSource(stateID: .combinedSessionState)
+        guard let keyDown = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true) else { return }
+        keyDown.flags = flags
+        keyDown.post(tap: .cgSessionEventTap)
+        print("[PadIO] Emitted key down: keyCode=0x\(String(keyCode, radix: 16)) flags=\(flags.rawValue)")
+    }
+
+    /// Emit only a key-up event. Used to release a held key.
+    func emitKeyUp(keyCode: CGKeyCode, flags: CGEventFlags = []) {
+        let source = CGEventSource(stateID: .combinedSessionState)
+        guard let keyUp = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false) else { return }
+        keyUp.flags = flags
+        keyUp.post(tap: .cgSessionEventTap)
+        print("[PadIO] Emitted key up: keyCode=0x\(String(keyCode, radix: 16)) flags=\(flags.rawValue)")
+    }
+
+    // MARK: - Mouse down / up / drag
+
+    /// Emit only a mouse-down event at the current cursor position.
+    func emitMouseDown(button: CGMouseButton) {
+        let source = CGEventSource(stateID: .combinedSessionState)
+        let pos = CGEvent(source: nil)?.location ?? .zero
+        let downType: CGEventType = button == .left ? .leftMouseDown : .rightMouseDown
+        guard let down = CGEvent(mouseEventSource: source, mouseType: downType, mouseCursorPosition: pos, mouseButton: button) else { return }
+        down.post(tap: .cgSessionEventTap)
+        print("[PadIO] Emitted mouse down: \(button == .left ? "left" : "right")")
+    }
+
+    /// Emit only a mouse-up event at the current cursor position.
+    func emitMouseUp(button: CGMouseButton) {
+        let source = CGEventSource(stateID: .combinedSessionState)
+        let pos = CGEvent(source: nil)?.location ?? .zero
+        let upType: CGEventType = button == .left ? .leftMouseUp : .rightMouseUp
+        guard let up = CGEvent(mouseEventSource: source, mouseType: upType, mouseCursorPosition: pos, mouseButton: button) else { return }
+        up.post(tap: .cgSessionEventTap)
+        print("[PadIO] Emitted mouse up: \(button == .left ? "left" : "right")")
+    }
+
+    /// Emit a mouse-drag event (mouse-moved while button is held).
+    func emitMouseDrag(dx: CGFloat, dy: CGFloat, button: CGMouseButton) {
+        let source = CGEventSource(stateID: .combinedSessionState)
+        let currentPos = CGEvent(source: nil)?.location ?? .zero
+        let newPos = CGPoint(x: currentPos.x + dx, y: currentPos.y + dy)
+        let dragType: CGEventType = button == .left ? .leftMouseDragged : .rightMouseDragged
+
+        guard let event = CGEvent(
+            mouseEventSource: source,
+            mouseType: dragType,
+            mouseCursorPosition: newPos,
+            mouseButton: button
+        ) else { return }
+
+        event.setIntegerValueField(.mouseEventDeltaX, value: Int64(dx))
+        event.setIntegerValueField(.mouseEventDeltaY, value: Int64(dy))
+        event.post(tap: .cgSessionEventTap)
+    }
+
     // MARK: - Mouse click
 
     /// Emit a mouse button down + up at the current cursor position.

--- a/PadIO/InputHandler.swift
+++ b/PadIO/InputHandler.swift
@@ -215,6 +215,41 @@ struct InputHandler {
         event.post(tap: .cgSessionEventTap)
     }
 
+    // MARK: - Modifier hold / release (flagsChanged)
+
+    /// Key codes for modifier keys used in flagsChanged events.
+    private static let modifierKeyCodes: [(flag: CGEventFlags, keyCode: CGKeyCode)] = [
+        (.maskCommand,     0x37),  // kVK_Command
+        (.maskShift,       0x38),  // kVK_Shift
+        (.maskAlternate,   0x3A),  // kVK_Option
+        (.maskControl,     0x3B),  // kVK_Control
+        (.maskSecondaryFn, 0x3F),  // kVK_Function (Globe)
+    ]
+
+    /// Emit a flagsChanged event to press modifier keys. macOS will treat these
+    /// modifiers as held until a corresponding release event is sent.
+    func emitModifierDown(flags: CGEventFlags) {
+        let source = CGEventSource(stateID: .combinedSessionState)
+        // Use the key code of the first matching modifier
+        let keyCode = Self.modifierKeyCodes.first(where: { flags.contains($0.flag) })?.keyCode ?? 0x37
+        guard let event = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: true) else { return }
+        event.type = .flagsChanged
+        event.flags = flags
+        event.post(tap: .cgSessionEventTap)
+        print("[PadIO] Emitted modifier down: flags=\(flags.rawValue)")
+    }
+
+    /// Emit a flagsChanged event to release modifier keys.
+    func emitModifierUp(flags: CGEventFlags) {
+        let source = CGEventSource(stateID: .combinedSessionState)
+        let keyCode = Self.modifierKeyCodes.first(where: { flags.contains($0.flag) })?.keyCode ?? 0x37
+        guard let event = CGEvent(keyboardEventSource: source, virtualKey: keyCode, keyDown: false) else { return }
+        event.type = .flagsChanged
+        event.flags = []  // Empty flags = all modifiers released
+        event.post(tap: .cgSessionEventTap)
+        print("[PadIO] Emitted modifier up: flags=\(flags.rawValue)")
+    }
+
     // MARK: - Individual key down / key up
 
     /// Emit only a key-down event (no matching key-up). Used for hold actions.

--- a/PadIO/MappingConfig.swift
+++ b/PadIO/MappingConfig.swift
@@ -93,6 +93,10 @@ struct MappingConfig: Codable, Sendable {
     var menus: [String: MenuConfig]
     /// Optional haptic/rumble configuration for system event triggers.
     var haptics: HapticsConfig?
+    /// Reusable action definitions, referenced by `{ "type": "alias", "name": "<key>" }`.
+    var aliases: [String: ActionConfig]?
+    /// Modes shared across profiles — any profile can reference these by name.
+    var sharedModes: [String: ModeConfig]?
 
     enum CodingKeys: String, CodingKey {
         case triggerThreshold = "trigger_threshold"
@@ -101,15 +105,19 @@ struct MappingConfig: Codable, Sendable {
         case profiles
         case menus
         case haptics
+        case aliases
+        case sharedModes = "shared_modes"
     }
 
-    init(triggerThreshold: Double?, debugOverlay: Bool?, global: [String: ActionConfig], profiles: [String: ProfileConfig], menus: [String: MenuConfig], haptics: HapticsConfig? = nil) {
+    init(triggerThreshold: Double?, debugOverlay: Bool?, global: [String: ActionConfig], profiles: [String: ProfileConfig], menus: [String: MenuConfig], haptics: HapticsConfig? = nil, aliases: [String: ActionConfig]? = nil, sharedModes: [String: ModeConfig]? = nil) {
         self.triggerThreshold = triggerThreshold
         self.debugOverlay = debugOverlay
         self.global = global
         self.profiles = profiles
         self.menus = menus
         self.haptics = haptics
+        self.aliases = aliases
+        self.sharedModes = sharedModes
     }
 
     init(from decoder: Decoder) throws {
@@ -120,6 +128,8 @@ struct MappingConfig: Codable, Sendable {
         profiles         = try container.decode([String: ProfileConfig].self, forKey: .profiles)
         menus            = try container.decodeIfPresent([String: MenuConfig].self, forKey: .menus) ?? [:]
         haptics          = try container.decodeIfPresent(HapticsConfig.self, forKey: .haptics)
+        aliases          = try container.decodeIfPresent([String: ActionConfig].self, forKey: .aliases)
+        sharedModes      = try container.decodeIfPresent([String: ModeConfig].self, forKey: .sharedModes)
     }
 
     static let empty = MappingConfig(triggerThreshold: nil, debugOverlay: nil, global: [:], profiles: [:], menus: [:])
@@ -201,8 +211,10 @@ final class ActionConfig: Codable, Sendable {
     let modifierSpeed: Double?
     /// Reserved for future dual-use: action config when button is pressed briefly.
     let trigger: ActionConfig?
-    /// Reserved for future dual-use: mode name to hold while button is held.
-    let hold: String?
+    /// Hold action config — when present, enables press-vs-hold behavior.
+    let hold: ActionConfig?
+    /// For "menu": the menu name (alternative to "menu:<name>" syntax).
+    let name: String?
     /// For "rumble": motor intensity (0.0–1.0). Default 0.5.
     let intensity: Double?
     /// For "rumble": haptic sharpness (0.0–1.0). Default 0.3.
@@ -219,10 +231,11 @@ final class ActionConfig: Codable, Sendable {
         case modifier
         case modifierSpeed = "modifier_speed"
         case trigger, hold
+        case name
         case intensity, sharpness
     }
 
-    init(type: String, key: String? = nil, modifiers: [String]? = nil, steps: [ActionConfig]? = nil, delay: Double? = nil, speed: Double? = nil, xSpeed: Double? = nil, ySpeed: Double? = nil, xInverted: Bool? = nil, yInverted: Bool? = nil, modifier: String? = nil, modifierSpeed: Double? = nil, trigger: ActionConfig? = nil, hold: String? = nil, intensity: Double? = nil, sharpness: Double? = nil) {
+    init(type: String, key: String? = nil, modifiers: [String]? = nil, steps: [ActionConfig]? = nil, delay: Double? = nil, speed: Double? = nil, xSpeed: Double? = nil, ySpeed: Double? = nil, xInverted: Bool? = nil, yInverted: Bool? = nil, modifier: String? = nil, modifierSpeed: Double? = nil, trigger: ActionConfig? = nil, hold: ActionConfig? = nil, name: String? = nil, intensity: Double? = nil, sharpness: Double? = nil) {
         self.type = type
         self.key = key
         self.modifiers = modifiers
@@ -237,6 +250,7 @@ final class ActionConfig: Codable, Sendable {
         self.modifierSpeed = modifierSpeed
         self.trigger = trigger
         self.hold = hold
+        self.name = name
         self.intensity = intensity
         self.sharpness = sharpness
     }

--- a/PadIO/MappingResolver.swift
+++ b/PadIO/MappingResolver.swift
@@ -53,6 +53,8 @@ enum Action: Sendable {
     case keyDown(keyCode: CGKeyCode, flags: CGEventFlags)
     /// Release a previously held key.
     case keyUp(keyCode: CGKeyCode, flags: CGEventFlags)
+    /// No-op action — does nothing. Used as a tap action when only the hold behavior is wanted.
+    case noop
     /// Hold modifier keys down via flagsChanged events (e.g., Cmd for app switcher).
     case modifierHold(flags: CGEventFlags)
     /// Release held modifier keys via flagsChanged events.
@@ -415,6 +417,9 @@ struct MappingResolver {
             let duration  = config.delay     ?? 0.2  // "delay" doubles as duration for rumble
             return .rumble(intensity: intensity, sharpness: sharpness, duration: duration)
 
+        case "none":
+            return .noop
+
         case "mouse_move", "scroll":
             // Axis-only types; not dispatched as one-shot Actions from the button pipeline.
             return nil
@@ -492,6 +497,9 @@ struct MappingResolver {
 
         case .keyUp(let keyCode, let flags):
             return "key_up: \(describeKeystroke(keyCode: keyCode, flags: flags))"
+
+        case .noop:
+            return "none"
 
         case .modifierHold(let flags):
             return "modifier_hold: \(describeModifiers(flags))"

--- a/PadIO/MappingResolver.swift
+++ b/PadIO/MappingResolver.swift
@@ -53,6 +53,10 @@ enum Action: Sendable {
     case keyDown(keyCode: CGKeyCode, flags: CGEventFlags)
     /// Release a previously held key.
     case keyUp(keyCode: CGKeyCode, flags: CGEventFlags)
+    /// Hold modifier keys down via flagsChanged events (e.g., Cmd for app switcher).
+    case modifierHold(flags: CGEventFlags)
+    /// Release held modifier keys via flagsChanged events.
+    case modifierRelease(flags: CGEventFlags)
 }
 
 // MARK: - Axis mapping
@@ -391,6 +395,14 @@ struct MappingResolver {
         case "right_click_hold":
             return .rightClickHold
 
+        case "modifier_hold":
+            let flags = Self.modifierFlags(for: config.modifiers ?? [])
+            guard flags != [] else {
+                print("[PadIO] modifier_hold action missing 'modifiers'")
+                return nil
+            }
+            return .modifierHold(flags: flags)
+
         case "keyboard_viewer":
             return .keyboardViewer
 
@@ -480,7 +492,30 @@ struct MappingResolver {
 
         case .keyUp(let keyCode, let flags):
             return "key_up: \(describeKeystroke(keyCode: keyCode, flags: flags))"
+
+        case .modifierHold(let flags):
+            return "modifier_hold: \(describeModifiers(flags))"
+
+        case .modifierRelease(let flags):
+            return "modifier_release: \(describeModifiers(flags))"
         }
+    }
+
+    private static func describeModifiers(_ flags: CGEventFlags) -> String {
+        let isHyper = flags.contains(.maskCommand) && flags.contains(.maskControl) &&
+                      flags.contains(.maskAlternate) && flags.contains(.maskShift)
+        let isMeh   = !flags.contains(.maskCommand) && flags.contains(.maskControl) &&
+                      flags.contains(.maskAlternate) && flags.contains(.maskShift)
+        if isHyper { return "hyper" }
+        if isMeh   { return "meh" }
+
+        var parts: [String] = []
+        if flags.contains(.maskCommand)     { parts.append("cmd") }
+        if flags.contains(.maskControl)     { parts.append("ctrl") }
+        if flags.contains(.maskAlternate)   { parts.append("alt") }
+        if flags.contains(.maskShift)       { parts.append("shift") }
+        if flags.contains(.maskSecondaryFn) { parts.append("globe") }
+        return parts.isEmpty ? "none" : parts.joined(separator: "+")
     }
 
     private static func describeKeystroke(keyCode: CGKeyCode, flags: CGEventFlags) -> String {
@@ -613,6 +648,8 @@ struct MappingResolver {
                 flags.insert(.maskControl)
                 flags.insert(.maskAlternate)
                 flags.insert(.maskShift)
+            case "globe", "fn":
+                flags.insert(.maskSecondaryFn)
             default:
                 print("[PadIO] Unknown modifier: '\(name)'")
             }

--- a/PadIO/MappingResolver.swift
+++ b/PadIO/MappingResolver.swift
@@ -41,6 +41,18 @@ enum Action: Sendable {
     case nextInputSource
     /// Fire a haptic rumble on all connected controllers.
     case rumble(intensity: Double, sharpness: Double, duration: Double)
+    /// Hold left mouse button down (for drag operations).
+    case leftClickHold
+    /// Release left mouse button.
+    case leftClickRelease
+    /// Hold right mouse button down.
+    case rightClickHold
+    /// Release right mouse button.
+    case rightClickRelease
+    /// Press a key down without releasing.
+    case keyDown(keyCode: CGKeyCode, flags: CGEventFlags)
+    /// Release a previously held key.
+    case keyUp(keyCode: CGKeyCode, flags: CGEventFlags)
 }
 
 // MARK: - Axis mapping
@@ -106,37 +118,37 @@ struct MappingResolver {
             let comboKey = "\(modifierID.rawValue)+\(key)"
 
             if let actionConfig = config.global[comboKey] {
-                return buildAction(from: actionConfig)
+                return buildAction(from: actionConfig, mappingConfig: config)
             }
             if let profile {
                 if let actionConfig = profile.global[comboKey] {
-                    return buildAction(from: actionConfig)
+                    return buildAction(from: actionConfig, mappingConfig: config)
                 }
                 if let modeName = activeMode,
-                   let mode = profile.modes[modeName],
+                   let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
                    let actionConfig = mode.bindings[comboKey] {
-                    return buildAction(from: actionConfig)
+                    return buildAction(from: actionConfig, mappingConfig: config)
                 }
             }
         }
 
         // 4. Top-level global (supersedes everything)
         if let actionConfig = config.global[key] {
-            return buildAction(from: actionConfig)
+            return buildAction(from: actionConfig, mappingConfig: config)
         }
 
         guard let profile else { return nil }
 
         // 5. Profile-level global
         if let actionConfig = profile.global[key] {
-            return buildAction(from: actionConfig)
+            return buildAction(from: actionConfig, mappingConfig: config)
         }
 
-        // 6. Active mode bindings
+        // 6. Active mode bindings (profile modes, then shared modes)
         if let modeName = activeMode,
-           let mode = profile.modes[modeName],
+           let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
            let actionConfig = mode.bindings[key] {
-            return buildAction(from: actionConfig)
+            return buildAction(from: actionConfig, mappingConfig: config)
         }
 
         return nil
@@ -161,7 +173,7 @@ struct MappingResolver {
         }
 
         if let modeName = activeMode,
-           let mode = profile.modes[modeName],
+           let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
            let actionConfig = mode.bindings[key] {
             return buildAxisMapping(from: actionConfig)
         }
@@ -210,11 +222,14 @@ struct MappingResolver {
         config: MappingConfig
     ) -> [(button: String, action: String)] {
         var result: [String: String] = [:]
+        let resolver = MappingResolver()
 
         // 3. Active mode bindings (lowest priority — add first so higher priority overwrites)
-        if let profile, let modeName = activeMode, let mode = profile.modes[modeName] {
+        // Check profile modes first, then shared modes
+        if let profile, let modeName = activeMode,
+           let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]) {
             for (button, actionConfig) in mode.bindings {
-                if let action = MappingResolver().buildAction(from: actionConfig) {
+                if let action = resolver.buildAction(from: actionConfig, mappingConfig: config) {
                     result[button] = Self.describe(action)
                 }
             }
@@ -223,7 +238,7 @@ struct MappingResolver {
         // 2. Profile-level global (overwrites mode bindings for the same button)
         if let profile {
             for (button, actionConfig) in profile.global {
-                if let action = MappingResolver().buildAction(from: actionConfig) {
+                if let action = resolver.buildAction(from: actionConfig, mappingConfig: config) {
                     result[button] = Self.describe(action)
                 }
             }
@@ -231,7 +246,7 @@ struct MappingResolver {
 
         // 1. Top-level global (highest priority — overwrites all)
         for (button, actionConfig) in config.global {
-            if let action = MappingResolver().buildAction(from: actionConfig) {
+            if let action = resolver.buildAction(from: actionConfig, mappingConfig: config) {
                 result[button] = Self.describe(action)
             }
         }
@@ -241,11 +256,36 @@ struct MappingResolver {
 
     // MARK: - Action building
 
-    func buildActionPublic(from config: ActionConfig) -> Action? {
-        buildAction(from: config)
+    func buildActionPublic(from config: ActionConfig, mappingConfig: MappingConfig? = nil) -> Action? {
+        buildAction(from: config, mappingConfig: mappingConfig)
     }
 
-    private func buildAction(from config: ActionConfig) -> Action? {
+    /// Resolves the raw ActionConfig for a button using the same cascade as resolve(),
+    /// but returns the config itself (needed to inspect the `hold` field).
+    func resolveActionConfig(button: ButtonID, heldButtons: [ButtonID: Bool] = [:], profile: ProfileConfig?, activeMode: String?, config: MappingConfig) -> ActionConfig? {
+        let key = button.rawValue
+
+        for modifierID in ButtonID.allCases {
+            guard modifierID != button, heldButtons[modifierID] == true else { continue }
+            let comboKey = "\(modifierID.rawValue)+\(key)"
+            if let ac = config.global[comboKey] { return ac }
+            if let profile {
+                if let ac = profile.global[comboKey] { return ac }
+                if let modeName = activeMode,
+                   let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
+                   let ac = mode.bindings[comboKey] { return ac }
+            }
+        }
+        if let ac = config.global[key] { return ac }
+        guard let profile else { return nil }
+        if let ac = profile.global[key] { return ac }
+        if let modeName = activeMode,
+           let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
+           let ac = mode.bindings[key] { return ac }
+        return nil
+    }
+
+    private func buildAction(from config: ActionConfig, mappingConfig: MappingConfig? = nil) -> Action? {
         switch config.type {
         case "keystroke":
             guard let keyName = config.key else {
@@ -308,6 +348,13 @@ struct MappingResolver {
             }
             return .setMode(name: name)
 
+        case "menu":
+            guard let name = config.name, !name.isEmpty else {
+                print("[PadIO] menu action missing 'name'")
+                return nil
+            }
+            return .openMenu(name: name)
+
         case _ where config.type.hasPrefix("menu:"):
             let name = String(config.type.dropFirst("menu:".count))
             guard !name.isEmpty else {
@@ -316,11 +363,33 @@ struct MappingResolver {
             }
             return .openMenu(name: name)
 
+        case "alias":
+            guard let name = config.name, !name.isEmpty else {
+                print("[PadIO] alias action missing 'name'")
+                return nil
+            }
+            guard let aliasConfig = mappingConfig?.aliases?[name] else {
+                print("[PadIO] Unknown alias: '\(name)'")
+                return nil
+            }
+            // Prevent alias chaining
+            guard aliasConfig.type != "alias" else {
+                print("[PadIO] Alias '\(name)' cannot reference another alias")
+                return nil
+            }
+            return buildAction(from: aliasConfig, mappingConfig: mappingConfig)
+
         case "left_click":
             return .leftClick
 
         case "right_click":
             return .rightClick
+
+        case "left_click_hold":
+            return .leftClickHold
+
+        case "right_click_hold":
+            return .rightClickHold
 
         case "keyboard_viewer":
             return .keyboardViewer
@@ -393,6 +462,24 @@ struct MappingResolver {
 
         case .rumble(let intensity, _, let duration):
             return "rumble i=\(String(format: "%.1f", intensity)) t=\(String(format: "%.2f", duration))s"
+
+        case .leftClickHold:
+            return "left_click_hold"
+
+        case .leftClickRelease:
+            return "left_click_release"
+
+        case .rightClickHold:
+            return "right_click_hold"
+
+        case .rightClickRelease:
+            return "right_click_release"
+
+        case .keyDown(let keyCode, let flags):
+            return "key_down: \(describeKeystroke(keyCode: keyCode, flags: flags))"
+
+        case .keyUp(let keyCode, let flags):
+            return "key_up: \(describeKeystroke(keyCode: keyCode, flags: flags))"
         }
     }
 

--- a/PadIO/MappingResolver.swift
+++ b/PadIO/MappingResolver.swift
@@ -109,12 +109,12 @@ struct MappingResolver {
     /// Resolves an action for a button press given the active profile and mode.
     ///
     /// Resolution cascade (combo keys first, then plain keys):
-    /// 1. Combo key in top-level `global`.
-    /// 2. Combo key in active mode bindings.
-    /// 3. Combo key in profile `global`.
-    /// 4. Plain key in top-level `global`.
-    /// 5. Plain key in active mode bindings.
-    /// 6. Plain key in profile `global` (defaults within a profile).
+    /// 1. Combo key in active mode bindings (highest priority).
+    /// 2. Combo key in profile `global`.
+    /// 3. Combo key in top-level `global` (cross-profile defaults).
+    /// 4. Plain key in active mode bindings (highest priority).
+    /// 5. Plain key in profile `global`.
+    /// 6. Plain key in top-level `global` (cross-profile defaults).
     func resolve(button: ButtonID, heldButtons: [ButtonID: Bool] = [:], profile: ProfileConfig?, activeMode: String?, config: MappingConfig) -> Action? {
         let key = button.rawValue
 
@@ -123,9 +123,6 @@ struct MappingResolver {
             guard modifierID != button, heldButtons[modifierID] == true else { continue }
             let comboKey = "\(modifierID.rawValue)+\(key)"
 
-            if let actionConfig = config.global[comboKey] {
-                return buildAction(from: actionConfig, mappingConfig: config)
-            }
             if let profile {
                 if let modeName = activeMode,
                    let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
@@ -136,24 +133,25 @@ struct MappingResolver {
                     return buildAction(from: actionConfig, mappingConfig: config)
                 }
             }
+            if let actionConfig = config.global[comboKey] {
+                return buildAction(from: actionConfig, mappingConfig: config)
+            }
         }
 
-        // 4. Top-level global (supersedes everything)
-        if let actionConfig = config.global[key] {
-            return buildAction(from: actionConfig, mappingConfig: config)
-        }
-
-        guard let profile else { return nil }
-
-        // 5. Active mode bindings (profile modes, then shared modes)
-        if let modeName = activeMode,
+        // 4. Active mode bindings (highest priority)
+        if let profile, let modeName = activeMode,
            let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
            let actionConfig = mode.bindings[key] {
             return buildAction(from: actionConfig, mappingConfig: config)
         }
 
-        // 6. Profile-level global (defaults within a profile)
-        if let actionConfig = profile.global[key] {
+        // 5. Profile-level global
+        if let profile, let actionConfig = profile.global[key] {
+            return buildAction(from: actionConfig, mappingConfig: config)
+        }
+
+        // 6. Top-level global (cross-profile defaults)
+        if let actionConfig = config.global[key] {
             return buildAction(from: actionConfig, mappingConfig: config)
         }
 
@@ -164,23 +162,21 @@ struct MappingResolver {
 
     /// Resolves an axis mapping for a given axis source using the same cascade as button resolution.
     ///
-    /// Resolution order: top-level global → active mode → profile global.
+    /// Resolution order: active mode → profile global → top-level global.
     func resolveAxisMapping(axisID: AxisID, profile: ProfileConfig?, activeMode: String?, config: MappingConfig) -> AxisMapping? {
         let key = axisID.rawValue
 
-        if let actionConfig = config.global[key] {
-            return buildAxisMapping(from: actionConfig)
-        }
-
-        guard let profile else { return nil }
-
-        if let modeName = activeMode,
+        if let profile, let modeName = activeMode,
            let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
            let actionConfig = mode.bindings[key] {
             return buildAxisMapping(from: actionConfig)
         }
 
-        if let actionConfig = profile.global[key] {
+        if let profile, let actionConfig = profile.global[key] {
+            return buildAxisMapping(from: actionConfig)
+        }
+
+        if let actionConfig = config.global[key] {
             return buildAxisMapping(from: actionConfig)
         }
 
@@ -230,7 +226,14 @@ struct MappingResolver {
         var result: [String: String] = [:]
         let resolver = MappingResolver()
 
-        // 3. Profile-level global (lowest priority — add first so higher priority overwrites)
+        // 3. Top-level global (lowest priority — add first so higher priority overwrites)
+        for (button, actionConfig) in config.global {
+            if let action = resolver.buildAction(from: actionConfig, mappingConfig: config) {
+                result[button] = Self.describe(action)
+            }
+        }
+
+        // 2. Profile-level global (overwrites top-level global)
         if let profile {
             for (button, actionConfig) in profile.global {
                 if let action = resolver.buildAction(from: actionConfig, mappingConfig: config) {
@@ -239,21 +242,13 @@ struct MappingResolver {
             }
         }
 
-        // 2. Active mode bindings (overwrites profile global for the same button)
-        // Check profile modes first, then shared modes
+        // 1. Active mode bindings (highest priority — overwrites all)
         if let profile, let modeName = activeMode,
            let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]) {
             for (button, actionConfig) in mode.bindings {
                 if let action = resolver.buildAction(from: actionConfig, mappingConfig: config) {
                     result[button] = Self.describe(action)
                 }
-            }
-        }
-
-        // 1. Top-level global (highest priority — overwrites all)
-        for (button, actionConfig) in config.global {
-            if let action = resolver.buildAction(from: actionConfig, mappingConfig: config) {
-                result[button] = Self.describe(action)
             }
         }
 
@@ -274,20 +269,19 @@ struct MappingResolver {
         for modifierID in ButtonID.allCases {
             guard modifierID != button, heldButtons[modifierID] == true else { continue }
             let comboKey = "\(modifierID.rawValue)+\(key)"
-            if let ac = config.global[comboKey] { return ac }
             if let profile {
                 if let modeName = activeMode,
                    let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
                    let ac = mode.bindings[comboKey] { return ac }
                 if let ac = profile.global[comboKey] { return ac }
             }
+            if let ac = config.global[comboKey] { return ac }
         }
-        if let ac = config.global[key] { return ac }
-        guard let profile else { return nil }
-        if let modeName = activeMode,
+        if let profile, let modeName = activeMode,
            let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
            let ac = mode.bindings[key] { return ac }
-        if let ac = profile.global[key] { return ac }
+        if let profile, let ac = profile.global[key] { return ac }
+        if let ac = config.global[key] { return ac }
         return nil
     }
 
@@ -297,27 +291,27 @@ struct MappingResolver {
         let key = button.rawValue
         var results: [ActionConfig] = []
 
-        // Combo keys
+        // Combo keys (mode → profile global → top global)
         for modifierID in ButtonID.allCases {
             guard modifierID != button, heldButtons[modifierID] == true else { continue }
             let comboKey = "\(modifierID.rawValue)+\(key)"
-            if let ac = config.global[comboKey] { results.append(ac) }
             if let profile {
                 if let modeName = activeMode,
                    let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
                    let ac = mode.bindings[comboKey] { results.append(ac) }
                 if let ac = profile.global[comboKey] { results.append(ac) }
             }
+            if let ac = config.global[comboKey] { results.append(ac) }
         }
 
-        // Plain keys
-        if let ac = config.global[key] { results.append(ac) }
+        // Plain keys (mode → profile global → top global)
         if let profile {
             if let modeName = activeMode,
                let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
                let ac = mode.bindings[key] { results.append(ac) }
             if let ac = profile.global[key] { results.append(ac) }
         }
+        if let ac = config.global[key] { results.append(ac) }
 
         return results
     }

--- a/PadIO/MappingResolver.swift
+++ b/PadIO/MappingResolver.swift
@@ -110,11 +110,11 @@ struct MappingResolver {
     ///
     /// Resolution cascade (combo keys first, then plain keys):
     /// 1. Combo key in top-level `global`.
-    /// 2. Combo key in profile `global`.
-    /// 3. Combo key in active mode bindings.
+    /// 2. Combo key in active mode bindings.
+    /// 3. Combo key in profile `global`.
     /// 4. Plain key in top-level `global`.
-    /// 5. Plain key in profile `global`.
-    /// 6. Plain key in active mode bindings.
+    /// 5. Plain key in active mode bindings.
+    /// 6. Plain key in profile `global` (defaults within a profile).
     func resolve(button: ButtonID, heldButtons: [ButtonID: Bool] = [:], profile: ProfileConfig?, activeMode: String?, config: MappingConfig) -> Action? {
         let key = button.rawValue
 
@@ -127,12 +127,12 @@ struct MappingResolver {
                 return buildAction(from: actionConfig, mappingConfig: config)
             }
             if let profile {
-                if let actionConfig = profile.global[comboKey] {
-                    return buildAction(from: actionConfig, mappingConfig: config)
-                }
                 if let modeName = activeMode,
                    let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
                    let actionConfig = mode.bindings[comboKey] {
+                    return buildAction(from: actionConfig, mappingConfig: config)
+                }
+                if let actionConfig = profile.global[comboKey] {
                     return buildAction(from: actionConfig, mappingConfig: config)
                 }
             }
@@ -145,15 +145,15 @@ struct MappingResolver {
 
         guard let profile else { return nil }
 
-        // 5. Profile-level global
-        if let actionConfig = profile.global[key] {
-            return buildAction(from: actionConfig, mappingConfig: config)
-        }
-
-        // 6. Active mode bindings (profile modes, then shared modes)
+        // 5. Active mode bindings (profile modes, then shared modes)
         if let modeName = activeMode,
            let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
            let actionConfig = mode.bindings[key] {
+            return buildAction(from: actionConfig, mappingConfig: config)
+        }
+
+        // 6. Profile-level global (defaults within a profile)
+        if let actionConfig = profile.global[key] {
             return buildAction(from: actionConfig, mappingConfig: config)
         }
 
@@ -164,7 +164,7 @@ struct MappingResolver {
 
     /// Resolves an axis mapping for a given axis source using the same cascade as button resolution.
     ///
-    /// Resolution order: top-level global → profile global → active mode bindings.
+    /// Resolution order: top-level global → active mode → profile global.
     func resolveAxisMapping(axisID: AxisID, profile: ProfileConfig?, activeMode: String?, config: MappingConfig) -> AxisMapping? {
         let key = axisID.rawValue
 
@@ -174,13 +174,13 @@ struct MappingResolver {
 
         guard let profile else { return nil }
 
-        if let actionConfig = profile.global[key] {
-            return buildAxisMapping(from: actionConfig)
-        }
-
         if let modeName = activeMode,
            let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
            let actionConfig = mode.bindings[key] {
+            return buildAxisMapping(from: actionConfig)
+        }
+
+        if let actionConfig = profile.global[key] {
             return buildAxisMapping(from: actionConfig)
         }
 
@@ -230,20 +230,20 @@ struct MappingResolver {
         var result: [String: String] = [:]
         let resolver = MappingResolver()
 
-        // 3. Active mode bindings (lowest priority — add first so higher priority overwrites)
-        // Check profile modes first, then shared modes
-        if let profile, let modeName = activeMode,
-           let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]) {
-            for (button, actionConfig) in mode.bindings {
+        // 3. Profile-level global (lowest priority — add first so higher priority overwrites)
+        if let profile {
+            for (button, actionConfig) in profile.global {
                 if let action = resolver.buildAction(from: actionConfig, mappingConfig: config) {
                     result[button] = Self.describe(action)
                 }
             }
         }
 
-        // 2. Profile-level global (overwrites mode bindings for the same button)
-        if let profile {
-            for (button, actionConfig) in profile.global {
+        // 2. Active mode bindings (overwrites profile global for the same button)
+        // Check profile modes first, then shared modes
+        if let profile, let modeName = activeMode,
+           let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]) {
+            for (button, actionConfig) in mode.bindings {
                 if let action = resolver.buildAction(from: actionConfig, mappingConfig: config) {
                     result[button] = Self.describe(action)
                 }
@@ -276,19 +276,50 @@ struct MappingResolver {
             let comboKey = "\(modifierID.rawValue)+\(key)"
             if let ac = config.global[comboKey] { return ac }
             if let profile {
-                if let ac = profile.global[comboKey] { return ac }
                 if let modeName = activeMode,
                    let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
                    let ac = mode.bindings[comboKey] { return ac }
+                if let ac = profile.global[comboKey] { return ac }
             }
         }
         if let ac = config.global[key] { return ac }
         guard let profile else { return nil }
-        if let ac = profile.global[key] { return ac }
         if let modeName = activeMode,
            let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
            let ac = mode.bindings[key] { return ac }
+        if let ac = profile.global[key] { return ac }
         return nil
+    }
+
+    /// Returns all matching ActionConfigs for a button across the full cascade, in priority order.
+    /// Used to merge press and hold from different cascade levels.
+    func resolveAllConfigs(button: ButtonID, heldButtons: [ButtonID: Bool] = [:], profile: ProfileConfig?, activeMode: String?, config: MappingConfig) -> [ActionConfig] {
+        let key = button.rawValue
+        var results: [ActionConfig] = []
+
+        // Combo keys
+        for modifierID in ButtonID.allCases {
+            guard modifierID != button, heldButtons[modifierID] == true else { continue }
+            let comboKey = "\(modifierID.rawValue)+\(key)"
+            if let ac = config.global[comboKey] { results.append(ac) }
+            if let profile {
+                if let modeName = activeMode,
+                   let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
+                   let ac = mode.bindings[comboKey] { results.append(ac) }
+                if let ac = profile.global[comboKey] { results.append(ac) }
+            }
+        }
+
+        // Plain keys
+        if let ac = config.global[key] { results.append(ac) }
+        if let profile {
+            if let modeName = activeMode,
+               let mode = (profile.modes[modeName] ?? config.sharedModes?[modeName]),
+               let ac = mode.bindings[key] { results.append(ac) }
+            if let ac = profile.global[key] { results.append(ac) }
+        }
+
+        return results
     }
 
     private func buildAction(from config: ActionConfig, mappingConfig: MappingConfig? = nil) -> Action? {

--- a/config.json
+++ b/config.json
@@ -1,10 +1,21 @@
 {
   "trigger_threshold": 0.5,
   "debug_overlay": true,
+  "aliases": {
+    "tmux_leader": { "type": "keystroke", "key": "a", "modifiers": ["ctrl"] }
+  },
+  "shared_modes": {
+    "media": {
+      "LB":         { "type": "keystroke", "key": "play_pause" },
+      "RB":         { "type": "keystroke", "key": "next_track" },
+      "dpad_up":    { "type": "keystroke", "key": "volume_up" },
+      "dpad_down":  { "type": "keystroke", "key": "volume_down" }
+    }
+  },
   "global": {
     "left_stick":  { "type": "mouse_move", "speed": 15, "modifier": "RB", "modifier_speed": 3 },
     "right_stick": { "type": "scroll", "speed": 3, "y_inverted": true },
-    "L3":          { "type": "left_click" },
+    "L3":          { "type": "left_click", "hold": { "type": "left_click_hold" } },
     "R3":          { "type": "right_click" }
   },
   "profiles": {
@@ -21,9 +32,7 @@
           "dpad_up":    { "type": "keystroke", "key": "up" },
           "dpad_down":  { "type": "keystroke", "key": "down" },
           "dpad_left":  { "type": "keystroke", "key": "left" },
-          "dpad_right": { "type": "keystroke", "key": "right" },
-          "LB":         { "type": "keystroke", "key": "play_pause" },
-          "RB":         { "type": "keystroke", "key": "next_track" }
+          "dpad_right": { "type": "keystroke", "key": "right" }
         }
       }
     },
@@ -40,7 +49,7 @@
           "A":          { "type": "keystroke", "key": "return" },
           "B":          { "type": "keystroke", "key": "c", "modifiers": ["ctrl"] },
           "X":          { "type": "keystroke", "key": "l", "modifiers": ["ctrl"] },
-          "Y":          { "type": "menu:git" },
+          "Y":          { "type": "menu", "name": "git" },
           "dpad_up":    { "type": "keystroke", "key": "up" },
           "dpad_down":  { "type": "keystroke", "key": "down" },
           "dpad_left":  { "type": "keystroke", "key": "left" },

--- a/docs/configuration/actions.md
+++ b/docs/configuration/actions.md
@@ -91,13 +91,44 @@ Switch directly to a named mode without opening the picker. The mode must exist 
 { "type": "mode:nvim" }
 ```
 
-## `menu:<name>`
+## `menu`
 
 Open a named custom menu overlay (defined in the top-level `menus` object). See [Custom Menus](menus.md).
 
 ```json
-{ "type": "menu:git" }
+{ "type": "menu", "name": "git" }
 ```
+
+| Field  | Type   | Required | Description |
+|--------|--------|----------|-------------|
+| `name` | string | yes      | Name of the menu (must match a key in the top-level `menus` object). |
+
+The legacy syntax `"type": "menu:git"` is still supported for backward compatibility.
+
+## `alias`
+
+Reference a reusable action defined in the top-level `aliases` object.
+
+```json
+{ "type": "alias", "name": "tmux_leader" }
+```
+
+| Field  | Type   | Required | Description |
+|--------|--------|----------|-------------|
+| `name` | string | yes      | Name of the alias (must match a key in the top-level `aliases` object). |
+
+Define aliases at the top level of your config:
+
+```json
+{
+  "aliases": {
+    "tmux_leader": { "type": "keystroke", "key": "a", "modifiers": ["ctrl"] },
+    "save":        { "type": "keystroke", "key": "s", "modifiers": ["cmd"] }
+  }
+}
+```
+
+Aliases cannot chain — an alias cannot reference another alias.
 
 ## `left_click` / `right_click`
 
@@ -109,6 +140,15 @@ Emit a left or right mouse click at the current cursor position. Requires Access
 ```
 
 Useful bound to thumbstick clicks (`L3`, `R3`) alongside axis-mapped stick movement.
+
+## `left_click_hold` / `right_click_hold`
+
+Hold a mouse button down (for drag operations). Used as hold actions — see [Press vs Hold](#press-vs-hold) below.
+
+```json
+{ "type": "left_click_hold" }
+{ "type": "right_click_hold" }
+```
 
 ## `mouse_move`
 
@@ -200,3 +240,33 @@ Fire a one-shot haptic rumble on all connected controllers. Has no effect on con
 | `delay`     | number | `0.2`   | Duration of the rumble in seconds. |
 
 Does not require Accessibility permission.
+
+## Press vs Hold
+
+Any action can distinguish between a quick **tap** and a **hold** by adding a `hold` field. When present, the button enters a state machine:
+
+- **Press:** Starts tracking. No action fires immediately.
+- **Still held after 300ms:** Fires the hold action. For `left_click_hold` / `right_click_hold`, emits mouse-down. For keystrokes, emits key-down only.
+- **Release before 300ms:** Fires the original (tap) action.
+- **Release after hold:** Fires the release counterpart (mouse-up / key-up).
+- **No `hold` field:** Existing behavior — action fires immediately on press.
+
+```json
+"L3": {
+  "type": "left_click",
+  "hold": { "type": "left_click_hold" }
+}
+```
+
+In this example, tapping L3 performs a click. Holding L3 holds the left mouse button down for dragging — moving the stick while holding L3 emits drag events instead of regular mouse-move events. Releasing L3 releases the mouse button.
+
+Keystroke hold example — hold to keep a modifier pressed:
+
+```json
+"A": {
+  "type": "keystroke", "key": "space",
+  "hold": { "type": "keystroke", "key": "shift" }
+}
+```
+
+Tapping A sends space. Holding A holds shift down until released.

--- a/docs/configuration/actions.md
+++ b/docs/configuration/actions.md
@@ -150,6 +150,34 @@ Hold a mouse button down (for drag operations). Used as hold actions — see [Pr
 { "type": "right_click_hold" }
 ```
 
+## `modifier_hold`
+
+Hold modifier keys down using proper `flagsChanged` events. macOS treats these as physically held modifiers until the button is released. Used as a hold action — see [Press vs Hold](#press-vs-hold) below.
+
+```json
+{ "type": "modifier_hold", "modifiers": ["cmd"] }
+{ "type": "modifier_hold", "modifiers": ["ctrl", "shift"] }
+{ "type": "modifier_hold", "modifiers": ["hyper"] }
+```
+
+| Field       | Type     | Required | Description |
+|-------------|----------|----------|-------------|
+| `modifiers` | string[] | yes      | Modifier keys to hold (see [Modifiers](../reference/modifiers.md)). Also supports `"globe"` / `"fn"`. |
+
+This enables workflows like the macOS app switcher:
+
+```json
+"LT": {
+  "type": "keystroke", "key": "tab", "modifiers": ["cmd"],
+  "hold": { "type": "modifier_hold", "modifiers": ["cmd"] }
+},
+"LT+dpad_right": { "type": "keystroke", "key": "right" },
+"LT+dpad_left":  { "type": "keystroke", "key": "left" }
+```
+
+- **Tap LT**: Cmd+Tab — quick switch to last app
+- **Hold LT**: holds Cmd down, opening the app switcher. Navigate with dpad arrows (which fire as `LT+dpad_*` combos). Release LT to confirm and release Cmd.
+
 ## `mouse_move`
 
 Map a joystick or dpad to continuous mouse cursor movement. Used as a binding with the [axis source name](../reference/axis-sources.md) as the key.

--- a/docs/configuration/menus.md
+++ b/docs/configuration/menus.md
@@ -19,8 +19,10 @@ Named menus are defined at the top level of the config under `"menus"`. Each men
 Open it from any binding:
 
 ```json
-"Y": { "type": "menu:git" }
+"Y": { "type": "menu", "name": "git" }
 ```
+
+The legacy syntax `"type": "menu:git"` is also supported.
 
 ## Navigation
 

--- a/docs/configuration/profiles.md
+++ b/docs/configuration/profiles.md
@@ -100,18 +100,16 @@ Combo keys work in top-level `global`, profile `global`, and mode bindings — a
 
 When a button is pressed, PadIO checks combo keys first (if any other buttons are held), then falls back to plain keys:
 
-1. **Combo key in top-level `global`**
-2. **Combo key in active mode bindings**
-3. **Combo key in profile `global`**
-4. **Plain key in top-level `global`**
-5. **Plain key in active mode bindings**
-6. **Plain key in profile `global`**
+1. **Combo key in active mode bindings** (highest priority)
+2. **Combo key in profile `global`**
+3. **Combo key in top-level `global`**
+4. **Plain key in active mode bindings** (highest priority)
+5. **Plain key in profile `global`**
+6. **Plain key in top-level `global`**
 
-Mode bindings override profile `global` for the same button. This lets you define defaults in profile `global` and override specific buttons per mode.
+Mode bindings have the highest priority, so switching to a mode can override any button — including those defined in top-level `global`. This lets you define cross-profile defaults in top-level `global` (stick mappings, click buttons) and override specific buttons per mode when needed.
 
 If multiple buttons are held simultaneously, PadIO tries them in `ButtonID` order and uses the first match.
-
-Top-level `global` has the highest priority — use it for bindings that should always be active (stick mappings, click buttons) regardless of profile or mode.
 
 ### Hold inheritance
 

--- a/docs/configuration/profiles.md
+++ b/docs/configuration/profiles.md
@@ -101,12 +101,37 @@ Combo keys work in top-level `global`, profile `global`, and mode bindings — a
 When a button is pressed, PadIO checks combo keys first (if any other buttons are held), then falls back to plain keys:
 
 1. **Combo key in top-level `global`**
-2. **Combo key in profile `global`**
-3. **Combo key in active mode bindings**
+2. **Combo key in active mode bindings**
+3. **Combo key in profile `global`**
 4. **Plain key in top-level `global`**
-5. **Plain key in profile `global`**
-6. **Plain key in active mode bindings**
+5. **Plain key in active mode bindings**
+6. **Plain key in profile `global`**
+
+Mode bindings override profile `global` for the same button. This lets you define defaults in profile `global` and override specific buttons per mode.
 
 If multiple buttons are held simultaneously, PadIO tries them in `ButtonID` order and uses the first match.
 
-This means you can set a button in the top-level `global` to guarantee it always does the same thing, while still allowing per-mode overrides for other buttons.
+Top-level `global` has the highest priority — use it for bindings that should always be active (stick mappings, click buttons) regardless of profile or mode.
+
+### Hold inheritance
+
+When a mode overrides a button that has a `hold` action defined at a lower priority level (e.g., profile `global`), the hold behavior is **inherited** automatically. Only the press (tap) action is overridden — the hold persists unless explicitly cleared.
+
+```json
+"global": {
+  "L3": { "type": "left_click", "hold": { "type": "left_click_hold" } }
+},
+"modes": {
+  "special": {
+    "L3": { "type": "keystroke", "key": "space" }
+  }
+}
+```
+
+In `special` mode, tapping L3 sends space, but holding L3 still holds the left mouse button (inherited from profile `global`).
+
+To explicitly clear an inherited hold, set the hold to `"none"`:
+
+```json
+"L3": { "type": "keystroke", "key": "space", "hold": { "type": "none" } }
+```

--- a/docs/configuration/profiles.md
+++ b/docs/configuration/profiles.md
@@ -40,6 +40,27 @@ A profile is a named set of bindings that applies when specific apps are in the 
 1. First profile whose `apps` list contains the frontmost app's bundle ID.
 2. The profile named `"default"` (fallback for unmatched apps).
 
+## Shared Modes
+
+Modes defined in the top-level `shared_modes` object are available to all profiles without redefinition. Any profile can reference a shared mode by name — it works the same as a profile-defined mode.
+
+```json
+{
+  "shared_modes": {
+    "media": {
+      "LB":         { "type": "keystroke", "key": "play_pause" },
+      "RB":         { "type": "keystroke", "key": "next_track" },
+      "dpad_up":    { "type": "keystroke", "key": "volume_up" },
+      "dpad_down":  { "type": "keystroke", "key": "volume_down" }
+    }
+  }
+}
+```
+
+Now every profile that supports mode switching can switch to `"media"` — the bindings are resolved from `shared_modes` when the active mode name isn't found in the profile's own `modes` dictionary.
+
+If a profile defines a mode with the same name as a shared mode, the profile's mode takes priority.
+
 ## Modes
 
 A mode is a flat object mapping button names to action objects:

--- a/docs/example-config.md
+++ b/docs/example-config.md
@@ -1,15 +1,26 @@
 # Example Config
 
-A complete annotated config demonstrating profiles, modes, sequences, custom menus, and axis mappings.
+A complete annotated config demonstrating profiles, modes, sequences, custom menus, aliases, shared modes, hold actions, and axis mappings.
 
 ```json
 {
   "trigger_threshold": 0.5,
   "debug_overlay": false,
+  "aliases": {
+    "tmux_leader": { "type": "keystroke", "key": "a", "modifiers": ["ctrl"] }
+  },
+  "shared_modes": {
+    "media": {
+      "LB":         { "type": "keystroke", "key": "play_pause" },
+      "RB":         { "type": "keystroke", "key": "next_track" },
+      "dpad_up":    { "type": "keystroke", "key": "volume_up" },
+      "dpad_down":  { "type": "keystroke", "key": "volume_down" }
+    }
+  },
   "global": {
     "left_stick":  { "type": "mouse_move", "speed": 15, "modifier": "RB", "modifier_speed": 3 },
     "right_stick": { "type": "scroll", "speed": 3, "y_inverted": true },
-    "L3":          { "type": "left_click" },
+    "L3":          { "type": "left_click", "hold": { "type": "left_click_hold" } },
     "R3":          { "type": "right_click" }
   },
   "profiles": {
@@ -26,9 +37,7 @@ A complete annotated config demonstrating profiles, modes, sequences, custom men
           "dpad_up":    { "type": "keystroke", "key": "up" },
           "dpad_down":  { "type": "keystroke", "key": "down" },
           "dpad_left":  { "type": "keystroke", "key": "left" },
-          "dpad_right": { "type": "keystroke", "key": "right" },
-          "LB":         { "type": "keystroke", "key": "play_pause" },
-          "RB":         { "type": "keystroke", "key": "next_track" }
+          "dpad_right": { "type": "keystroke", "key": "right" }
         }
       }
     },
@@ -45,7 +54,7 @@ A complete annotated config demonstrating profiles, modes, sequences, custom men
           "A":          { "type": "keystroke", "key": "return" },
           "B":          { "type": "keystroke", "key": "c", "modifiers": ["ctrl"] },
           "X":          { "type": "keystroke", "key": "l", "modifiers": ["ctrl"] },
-          "Y":          { "type": "menu:git" },
+          "Y":          { "type": "menu", "name": "git" },
           "dpad_up":    { "type": "keystroke", "key": "up" },
           "dpad_down":  { "type": "keystroke", "key": "down" },
           "dpad_left":  { "type": "keystroke", "key": "left" },
@@ -122,10 +131,13 @@ This config:
 
 - Maps the **left stick** to mouse movement globally, with RB as a speed boost modifier
 - Maps the **right stick** to scrolling globally (inverted Y for natural scroll)
-- **L3/R3** (stick clicks) for left/right click
-- **Default profile**: basic arrow keys, space, escape, media controls
+- **L3** (left stick click) for left click, with **hold for drag** — tap clicks, hold drags
+- **R3** (right stick click) for right click
+- **Aliases**: `tmux_leader` defined once, reusable across bindings
+- **Shared modes**: `media` mode available in all profiles for play/pause, track skip, volume
+- **Default profile**: basic arrow keys, space, escape
 - **Terminal profile**: activated for Ghostty, Terminal, and iTerm2
-    - **shell mode**: return, ctrl-c, ctrl-l, git menu on Y
+    - **shell mode**: return, ctrl-c, ctrl-l, git menu on Y (using `"type": "menu", "name": "git"` syntax)
     - **nvim mode**: vim-style hjkl navigation, with X+dpad combos for ctrl-j/ctrl-k (half-page scroll)
     - **tmux mode**: prefix sequences (ctrl-a + key) for pane navigation
 - **Git menu**: quick terminal commands accessible via Y button in shell mode

--- a/docs/reference/axis-sources.md
+++ b/docs/reference/axis-sources.md
@@ -8,5 +8,7 @@ Use these as binding keys alongside button names in any `global` or mode binding
 | `right_stick`  | Right thumbstick (analog, -1…+1 per axis)       |
 | `dpad`         | D-pad (treated as digital: -1, 0, or +1)        |
 
+Joystick axes use a **quadratic response curve** (`value × |value|`) after the deadzone. This preserves sign, gives fine control near the center, and amplifies large deflections for fast movement at full tilt.
+
 !!! note
     When `dpad` is used as an axis source for `mouse_move` or `scroll`, the individual dpad direction buttons (`dpad_up`, `dpad_down`, etc.) should not also be bound in the same mode — they will still fire as buttons.

--- a/docs/reference/modifiers.md
+++ b/docs/reference/modifiers.md
@@ -10,6 +10,7 @@ Modifiers are specified in the `modifiers` array of a [`keystroke`](../configura
 | `shift`             | Shift (⇧)                        |
 | `hyper`             | ⌘ + ⌃ + ⌥ + ⇧ (all four)       |
 | `meh`               | ⌃ + ⌥ + ⇧ (everything but ⌘)   |
+| `globe` / `fn`      | Globe / Fn (🌐)                  |
 
 ## Usage
 


### PR DESCRIPTION
## Summary

Implements all enhancements from issue #3 plus follow-up refinements:

- **Exponential joystick curves** — quadratic response (`x * abs(x)`) for precise small movements and fast full-deflection
- **Press vs hold** — buttons can have separate tap and hold actions (e.g., tap=click, hold=drag) with 300ms threshold and hold inheritance across cascade levels
- **Modifier hold** — `modifier_hold` action type for holding modifier keys (Cmd, Shift, etc.) via proper `flagsChanged` events; held modifier flags auto-merge into subsequent keystrokes
- **`none` action type** — no-op for hold-only buttons (no tap action)
- **Aliases** — reusable action definitions via top-level `aliases` dictionary
- **Shared modes** — modes defined at top level, reusable across all profiles
- **Menu config cleanup** — `"type": "menu", "name": "git"` syntax (backward-compatible with `"type": "menu:git"`)
- **Sequence-in-menu fix** — sequences dispatched off main thread so CGEvents deliver correctly from menu callbacks
- **Cascade reorder** — mode > profile global > top-level global (modes override everything, top-level global serves as cross-profile defaults)

## Test plan

- [ ] Verify joystick: small movements are precise, full deflection is fast
- [ ] Verify press-vs-hold: tap L3 = click, hold L3 = drag
- [ ] Verify modifier_hold: hold LT for Cmd, use dpad to navigate app switcher
- [ ] Verify `"type": "none"` suppresses tap action on hold-only buttons
- [ ] Verify aliases resolve correctly in bindings
- [ ] Verify shared modes work across multiple profiles
- [ ] Verify mode bindings override top-level global (e.g., shared mode dpad overrides global dpad)
- [ ] Verify sequences in menus execute correctly
- [ ] Verify config hot-reload still works

Closes #3

🤖 Generated with [Claude Code](https://claude.com/claude-code)