### PR TITLE
Add release workflow and Gatekeeper docs

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -10,7 +10,9 @@ permissions:
 
 jobs:
   release:
-    if: github.event.pull_request.merged == true
+    if: >-
+      github.event.pull_request.merged == true &&
+      contains(github.event.pull_request.labels.*.name, 'release')
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,69 @@
+name: Release
+
+on:
+  pull_request:
+    types: [closed]
+    branches: [main]
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    if: github.event.pull_request.merged == true
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+          token: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Compute next version (CalVer YYYY.M.patch)
+        id: version
+        run: |
+          YEAR=$(date -u +%Y)
+          MONTH=$(date -u +%-m)
+          PREFIX="${YEAR}.${MONTH}"
+
+          # Find the latest tag matching this month's prefix
+          LATEST=$(git tag --list "v${PREFIX}.*" --sort=-v:refname | head -n1)
+          if [ -z "$LATEST" ]; then
+            PATCH=0
+          else
+            PATCH=$(echo "$LATEST" | sed "s/v${PREFIX}\\.//")
+            PATCH=$((PATCH + 1))
+          fi
+
+          VERSION="${PREFIX}.${PATCH}"
+          echo "version=${VERSION}" >> "$GITHUB_OUTPUT"
+          echo "tag=v${VERSION}" >> "$GITHUB_OUTPUT"
+
+      - name: Update version in Xcode project
+        run: |
+          VERSION="${{ steps.version.outputs.version }}"
+          sed -i "s/MARKETING_VERSION = .*/MARKETING_VERSION = ${VERSION};/" \
+            PadIO.xcodeproj/project.pbxproj
+          sed -i "s/CURRENT_PROJECT_VERSION = .*/CURRENT_PROJECT_VERSION = ${VERSION};/" \
+            PadIO.xcodeproj/project.pbxproj
+
+      - name: Commit version bump and tag
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          VERSION="${{ steps.version.outputs.version }}"
+
+          git config user.name "github-actions[bot]"
+          git config user.email "github-actions[bot]@users.noreply.github.com"
+          git add PadIO.xcodeproj/project.pbxproj
+          git commit -m "Bump version to ${VERSION}" || echo "No changes to commit"
+          git tag -a "${TAG}" -m "Release ${VERSION}"
+          git push origin main --follow-tags
+
+      - name: Create GitHub Release
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+        run: |
+          TAG="${{ steps.version.outputs.tag }}"
+          gh release create "${TAG}" \
+            --title "${TAG}" \
+            --generate-notes \
+            --notes-start-tag "$(git tag --sort=-v:refname | sed -n '2p')"

--- a/docs/installation.md
+++ b/docs/installation.md
@@ -8,6 +8,9 @@ brew install --cask vgreg/tap/padio
 
 This installs PadIO to your Applications folder. Launch it from Spotlight or the Applications folder — it runs as a menu bar icon with no main window.
 
+!!! note "Gatekeeper warning"
+    PadIO is not notarized, so macOS will show a security warning on first launch. To bypass it, right-click the app → **Open** → **Open** in the dialog. You only need to do this once.
+
 ## Build from source
 
 ### Requirements


### PR DESCRIPTION
## Summary

- Add GitHub Actions release workflow with CalVer auto-versioning (YYYY.M.patch) on PR merge to main
- Release only triggers when PR has the `release` label (docs-only merges skip versioning)
- Add Gatekeeper bypass note to installation docs

## Test plan

- [ ] Merge this PR with `release` label and verify the workflow creates a tag + GitHub Release
- [ ] Verify docs deploy to GitHub Pages on merge

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)